### PR TITLE
Fix for issue #19 - Memory Leak issues caused by Name or x:Name Area reference

### DIFF
--- a/Notifications.Wpf.Sample/MainWindow.xaml
+++ b/Notifications.Wpf.Sample/MainWindow.xaml
@@ -13,7 +13,6 @@
             <Button Content="Show" Click="Button_Click"/>
             <Button Content="Show in window" Click="Button_Click_1" />
         </UniformGrid>
-        <!--<controls:NotificationArea x:Name="WindowArea" Position="TopLeft" MaxItems="3"/>-->
         <controls:NotificationArea AreaName="WindowArea" Position="TopLeft" MaxItems="3"/>
     </DockPanel>
 </Window>

--- a/Notifications.Wpf.Sample/MainWindow.xaml
+++ b/Notifications.Wpf.Sample/MainWindow.xaml
@@ -13,6 +13,7 @@
             <Button Content="Show" Click="Button_Click"/>
             <Button Content="Show in window" Click="Button_Click_1" />
         </UniformGrid>
-        <controls:NotificationArea x:Name="WindowArea" Position="TopLeft" MaxItems="3"/>
+        <!--<controls:NotificationArea x:Name="WindowArea" Position="TopLeft" MaxItems="3"/>-->
+        <controls:NotificationArea AreaName="WindowArea" Position="TopLeft" MaxItems="3"/>
     </DockPanel>
 </Window>

--- a/Notifications.Wpf/Controls/NotificationArea.cs
+++ b/Notifications.Wpf/Controls/NotificationArea.cs
@@ -9,9 +9,16 @@ using System.Windows.Threading;
 
 namespace Notifications.Wpf.Controls
 {
-    public class NotificationArea : Control
+    public class NotificationArea : Control, IDisposable
     {
+        public string AreaName
+        {
+            get { return (string)GetValue(AreaNameProp); }
+            set { SetValue(AreaNameProp, value); }
+        }
 
+        public static readonly DependencyProperty AreaNameProp =
+            DependencyProperty.Register("AreaName", typeof(string), typeof(NotificationArea), new PropertyMetadata(string.Empty));
 
 
         public NotificationPosition Position
@@ -30,7 +37,7 @@ namespace Notifications.Wpf.Controls
             get { return (int)GetValue(MaxItemsProperty); }
             set { SetValue(MaxItemsProperty, value); }
         }
-        
+
         public static readonly DependencyProperty MaxItemsProperty =
             DependencyProperty.Register("MaxItems", typeof(int), typeof(NotificationArea), new PropertyMetadata(int.MaxValue));
 
@@ -38,7 +45,13 @@ namespace Notifications.Wpf.Controls
 
         public NotificationArea()
         {
+            this.Unloaded += NotificationArea_Unloaded;
             NotificationManager.AddArea(this);
+        }
+
+        private void NotificationArea_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Dispose();
         }
 
         static NotificationArea()
@@ -64,7 +77,7 @@ namespace Notifications.Wpf.Controls
             {
                 Content = content
             };
-            
+
             notification.MouseLeftButtonDown += (sender, args) =>
             {
                 if (onClick != null)
@@ -108,7 +121,7 @@ namespace Notifications.Wpf.Controls
             }
             await Task.Delay(expirationTime);
 #endif
-                notification.Close();
+            notification.Close();
 #if NET40
             });
 #endif
@@ -138,6 +151,12 @@ namespace Notifications.Wpf.Controls
             }
         }
 #endif
+
+        public void Dispose()
+        {
+            this.Unloaded -= NotificationArea_Unloaded;
+            NotificationManager.RemoveArea(this);
+        }
     }
 
     public enum NotificationPosition

--- a/Notifications.Wpf/INotificationManager.cs
+++ b/Notifications.Wpf/INotificationManager.cs
@@ -4,6 +4,6 @@ namespace Notifications.Wpf
 {
     public interface INotificationManager
     {
-        void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null);
+        void Show(object content, string areaIdentifier = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null);
     }
 }

--- a/Notifications.Wpf/INotificationManager.cs
+++ b/Notifications.Wpf/INotificationManager.cs
@@ -4,6 +4,6 @@ namespace Notifications.Wpf
 {
     public interface INotificationManager
     {
-        void Show(object content, string areaIdentifier = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null);
+        void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null);
     }
 }

--- a/Notifications.Wpf/NotificationManager.cs
+++ b/Notifications.Wpf/NotificationManager.cs
@@ -23,19 +23,19 @@ namespace Notifications.Wpf
             _dispatcher = dispatcher;
         }
 
-        public void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null,
+        public void Show(object content, string areaIdentifier = "", TimeSpan? expirationTime = null, Action onClick = null,
             Action onClose = null)
         {
             if (!_dispatcher.CheckAccess())
             {
                 _dispatcher.BeginInvoke(
-                    new Action(() => Show(content, areaName, expirationTime, onClick, onClose)));
+                    new Action(() => Show(content, areaIdentifier, expirationTime, onClick, onClose)));
                 return;
             }
 
             if (expirationTime == null) expirationTime = TimeSpan.FromSeconds(5);
 
-            if (areaName == string.Empty && _window == null)
+            if (areaIdentifier == string.Empty && _window == null)
             {
                 var workArea = SystemParameters.WorkArea;
 
@@ -50,15 +50,20 @@ namespace Notifications.Wpf
                 _window.Show();
             }
 
-            foreach (var area in Areas.Where(a => a.Name == areaName))
+            foreach (var area in Areas.Where(a => a.AreaName == areaIdentifier))
             {
-                area.Show(content, (TimeSpan) expirationTime, onClick, onClose);
+                area.Show(content, (TimeSpan)expirationTime, onClick, onClose);
             }
         }
 
         internal static void AddArea(NotificationArea area)
         {
             Areas.Add(area);
+        }
+
+        internal static void RemoveArea(NotificationArea area)
+        {
+            Areas.Remove(area);
         }
     }
 }

--- a/Notifications.Wpf/NotificationManager.cs
+++ b/Notifications.Wpf/NotificationManager.cs
@@ -23,19 +23,19 @@ namespace Notifications.Wpf
             _dispatcher = dispatcher;
         }
 
-        public void Show(object content, string areaIdentifier = "", TimeSpan? expirationTime = null, Action onClick = null,
+        public void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null,
             Action onClose = null)
         {
             if (!_dispatcher.CheckAccess())
             {
                 _dispatcher.BeginInvoke(
-                    new Action(() => Show(content, areaIdentifier, expirationTime, onClick, onClose)));
+                    new Action(() => Show(content, areaName, expirationTime, onClick, onClose)));
                 return;
             }
 
             if (expirationTime == null) expirationTime = TimeSpan.FromSeconds(5);
 
-            if (areaIdentifier == string.Empty && _window == null)
+            if (areaName == string.Empty && _window == null)
             {
                 var workArea = SystemParameters.WorkArea;
 
@@ -50,7 +50,7 @@ namespace Notifications.Wpf
                 _window.Show();
             }
 
-            foreach (var area in Areas.Where(a => a.AreaName == areaIdentifier))
+            foreach (var area in Areas.Where(a => a.AreaName == areaName))
             {
                 area.Show(content, (TimeSpan)expirationTime, onClick, onClose);
             }


### PR DESCRIPTION
- Specific Dependency Property "AreaName" implementation to avoid Name or x:Name usage
- IDisposable implementation
- Remove method implementation on NotificationManager's cache